### PR TITLE
Ch4

### DIFF
--- a/nuxt-project/components/AppNavigation.vue
+++ b/nuxt-project/components/AppNavigation.vue
@@ -1,0 +1,6 @@
+<template>
+  <ul>
+    <li><router-link to="/">home</router-link></li>
+    <li><router-link to="/child">child</router-link></li>
+  </ul>
+</template>

--- a/nuxt-project/layouts/default.vue
+++ b/nuxt-project/layouts/default.vue
@@ -1,8 +1,19 @@
 <template>
   <div>
+    <AppNavigation />
     <nuxt/>
   </div>
 </template>
+
+<script>
+  import AppNavigation from '~/components/AppNavigation.vue'
+
+  export default {
+    components: {
+      AppNavigation
+    }
+  }
+</script>
 
 <style>
 html {

--- a/nuxt-project/layouts/error.vue
+++ b/nuxt-project/layouts/error.vue
@@ -1,0 +1,23 @@
+<template>
+  <div class="container">
+    <template v-if="isNotFound">
+      <h1>404 not found</h1>
+      <nuxt-link to="/">Back to home</nuxt-link>
+    </template>
+    <template v-else>
+      <h1>Error</h1>
+      <nuxt-link to="/">Back to home</nuxt-link>
+    </template>
+  </div>
+</template>
+
+<script>
+  export default {
+    props: ['error'],
+    computed: {
+      isNotFound() {
+        return this.error.statusCode === 404
+      }
+    }
+  }
+</script>

--- a/nuxt-project/middleware/redirector.js
+++ b/nuxt-project/middleware/redirector.js
@@ -1,0 +1,3 @@
+export default function({ redirect, route }) {
+  if (route.path === '/users/2') redirect('/')
+}

--- a/nuxt-project/nuxt.config.js
+++ b/nuxt-project/nuxt.config.js
@@ -23,6 +23,7 @@ module.exports = {
   ],
   plugins: [
     '~/plugins/axios',
+    '~/plugins/logger',
   ],
   /*
   ** Build configuration

--- a/nuxt-project/nuxt.config.js
+++ b/nuxt-project/nuxt.config.js
@@ -17,9 +17,6 @@ module.exports = {
   ** Customize the progress bar color
   */
   loading: { color: '#3B8070' },
-  router: {
-    middleware: ['redirector']
-  },
   modules: [
     '@nuxtjs/axios',
     '@nuxtjs/dotenv',

--- a/nuxt-project/nuxt.config.js
+++ b/nuxt-project/nuxt.config.js
@@ -17,6 +17,9 @@ module.exports = {
   ** Customize the progress bar color
   */
   loading: { color: '#3B8070' },
+  router: {
+    middleware: ['redirector']
+  },
   modules: [
     '@nuxtjs/axios',
     '@nuxtjs/dotenv',

--- a/nuxt-project/pages/child.vue
+++ b/nuxt-project/pages/child.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <h1>Child</h1>
+  </div>
+</template>

--- a/nuxt-project/pages/users/_id.vue
+++ b/nuxt-project/pages/users/_id.vue
@@ -9,6 +9,7 @@
   import { mapGetters } from 'vuex'
 
   export default {
+    middleware: 'redirector',
     async asyncData({ params, store }) {
       const { id } = params
       await store.dispatch('getUser', { id })

--- a/nuxt-project/plugins/logger.js
+++ b/nuxt-project/plugins/logger.js
@@ -1,0 +1,6 @@
+export default ({ app }) => {
+  app.router.beforeEach((to, from, next) => {
+    console.log(`move to "${to.fullPath}"`)
+    next()
+  })
+}

--- a/nuxt-project/store/index.js
+++ b/nuxt-project/store/index.js
@@ -1,29 +1,11 @@
 import Vuex from 'vuex'
 
-const store = () => new Vuex.Store({
-  state: {
-    user: null,
-  },
-  getters: {
-    user: (state) => state.user
-  },
-  mutations: {
-    saveUser(state, { user }) {
-      state.user = user
-    }
-  },
-  actions: {
-    async getUser({ commit }, { id }) {
-      try {
-        const user = await this.$axios.$get(
-          `https://api.github.com/users/${id}`
-        )
-        commit('saveUser', { user })
-      } catch(e) {
-        return Promise.reject(e)
-      }
-    }
-  }
+export const state = () => ({
+  isLoading: false
 })
 
-export default store
+export const mutations = {
+  setIsLoading(state, isLoading) {
+    state.isLoading = isLoading
+  }
+}

--- a/nuxt-project/store/user.js
+++ b/nuxt-project/store/user.js
@@ -1,0 +1,17 @@
+import Vuex from 'vuex'
+
+export const state = () => ({
+  list: []
+})
+
+export const mutations = {
+  addUser(state, user) {
+    state.list.push(user)
+  }
+}
+
+export const actions = {
+  addUser({ commit }, { user }) {
+    commit('addUser', user)
+  }
+}


### PR DESCRIPTION
## layouts
* レイアウトの共通化したいファイルを置くディレクトリ
* デフォルトのレイアウトファイル(フォールバック先)は、`default.vue`
* 実際に使うときは、以下のように分けるとよい
  * 一番よく使うレイアウトを`default.vue`に記述する
  * 特定のページ(e.g. トップページのLP、ダッシュボードのサマリー)でしか使わないレイアウトを `xxx.vue`にして、必要なページで`layout: 'xxx'`にする

## middleware
* ルーティングの処理の前後に割り込んで、request / responseオブジェクトの改ざんなどができる
* Nuxtの場合は、Vuexストアへのアクセスやリダイレクトの発行も可能
* 注意点
  * SSRモードじゃないと使えない (requestオブジェクトへのアクセスを必要とするため)
  * SSRモードでも初回アクセス時のみ有効なので、SPAモードに移行した途端にmiddleware機能は使えない(上と同じ理由)
  * middlewareはサーバー側の処理の一環なので、外部APIへのfetchなどがある場合、レスポンス速度に多少なりとも影響する

### 実装方法
* `middleware`ディレクトリ配下にJSファイルを作成する
* グローバルで利用するmiddlewareは、`nuxt.config.js`で、`router: { middleware: ['追加したいmiddleware名'] }`
* ページコンポーネント内でのみ利用するmiddlewareは、コンポーネント内のJSで` middleware: 追加したいmiddleware名`

## plugin
* 初期ロード時に自動で読み込み、特定の処理を行う
* middlewareとの使い分け
  * middlewareはページ処理の前後に挟まるフックで、リクエスト・レスポンスに対する処理が主体の場合
  * pluginはグローバルの機能拡張で、ライブラリの登録など、リクエスト・レスポンスに直接関係のない処理が主体の場合 (e.g. Google Analyticsのロギング)

### 実装方法
* `plugins`ディレクトリ配下にJSファイルを作成する
* プラグインの登録は、`nuxt.config.js`で、`plugins: [追加したいplugin名]`

## Vuexストアへのアクセス方法
* 2つのモードがある
* 小規模な開発以外では、モジュールモードを使うことが推奨

<table>
  <tr>
    <th>モード名</th>
    <th>概要</th>
  </tr>
  <tr>
    <td>クラシックモード</td>
    <td>単一の名前空間を持つVuexストア。<br />モジュールが必要な場合は手動で追加する。</td>
  </tr>
  <tr>
    <td>モジュールモード</td>
    <td>Nuxtのルールに従って記述することで、名前空間付きのモジュールと解釈して、Vuexストアインスタンスにまとめてくれる。</td>
  </tr>
</table>

### モジュールモードの利用方法
* `store`ディレクトリ配下にJSファイルを作成する
* exportは`state`, `mutation`, `action`の単位で行う (Vuexストアインスタンスではない)
* `index.js`がルートモジュール、それ以外の`*.js`はファイル名が名前空間となったモジュールとして登録される

## `<no-ssr>`
* `<no-ssr>`内のHTMLについてはレンダリングをスキップし、だいたいテキストを表示するためのコンポーネント
* [egoist/vue-no-ssr: Vue component to wrap non SSR friendly components (428 bytes)](https://github.com/egoist/vue-no-ssr) を移植したものだが、Nuxt側でグローバル定義されているので、自分でimportしないでも使える
* ユースケースとしては、コンポーネント全体で処理を切り分けたい場合に使う

## `process.browser`
* Node.jsのprocessオブジェクトを拡張した、boolean型の変数
* SSR実行時は`false`、ブラウザ上でSPAとして実行時は`true`へとNuxtが切り替えてくれる
* ユースケースとしては、コンポーネント内の一部で処理を切り分けたい場合に使う

## エラーページ
* Nuxtでは4xxと5xxのエラーが出た場合、`layouts/error.vue`を表示する (一つのテンプレートでまとめてエラー画面を管理できる)
* `layouts/error.vue`はレイアウトファイルは、実体はページファイルと似ている
  * `<nuxt>`タグを持たない
  * 他のレイアウトをベースとして指定できる